### PR TITLE
Fix version badge not showing all versions

### DIFF
--- a/CFReader.py
+++ b/CFReader.py
@@ -1,6 +1,6 @@
 import re
 import urllib2
-import lxml.html
+from lxml import html
 from lxml.cssselect import CSSSelector
 
 def get_project(project):
@@ -20,7 +20,7 @@ def get_downloads(project):
 
 
 def get_versions(project):
-    tree = lxml.html.fromstring(get_files(project))
+    tree = html.fromstring(get_files(project))
     sel = CSSSelector('option.game-version-type')
     results = [ele.text.replace('Minecraft ', '') for ele in sel(tree) if 'Minecraft' in ele.text]
     if len(results) > 0:

--- a/CFReader.py
+++ b/CFReader.py
@@ -1,10 +1,10 @@
 import re
 import urllib2
-
+import lxml.html
+from lxml.cssselect import CSSSelector
 
 def get_project(project):
     return urllib2.urlopen("https://minecraft.curseforge.com/projects/" + project).read()
-
 
 def get_downloads(project):
     response = get_project(project)
@@ -17,13 +17,14 @@ def get_downloads(project):
 
 
 def get_versions(project):
-    response = get_project(project)
-    pattern = '<h4 class="e-sidebar-subheader overflow-tip">\s+<a.*?>\s+Minecraft (.*?)\s+</a>\s+</h4>'
-    versions = re.findall(pattern, response)
-    if len(versions) > 0:
-        return versions
+    r = urllib2.urlopen('https://minecraft.curseforge.com/projects/' + project + '/files')
+    tree = lxml.html.fromstring(r.read())
+    sel = CSSSelector('option.game-version-type')
+    results = [ele.text.replace('Minecraft ', '') for ele in sel(tree) if 'Minecraft' in ele.text]
+    if len(results) > 0:
+       return results
     else:
-        return 'Error'
+        return ['Error']
 
 
 def get_tile(project):

--- a/CFReader.py
+++ b/CFReader.py
@@ -6,6 +6,9 @@ from lxml.cssselect import CSSSelector
 def get_project(project):
     return urllib2.urlopen("https://minecraft.curseforge.com/projects/" + project).read()
 
+def get_files(project):
+    return get_project(project + "/files")
+
 def get_downloads(project):
     response = get_project(project)
     pattern = 'Total Downloads\s*</div>\s*<div class="info-data">(.*?)</div>'
@@ -17,8 +20,7 @@ def get_downloads(project):
 
 
 def get_versions(project):
-    r = urllib2.urlopen('https://minecraft.curseforge.com/projects/' + project + '/files')
-    tree = lxml.html.fromstring(r.read())
+    tree = lxml.html.fromstring(get_files(project))
     sel = CSSSelector('option.game-version-type')
     results = [ele.text.replace('Minecraft ', '') for ele in sel(tree) if 'Minecraft' in ele.text]
     if len(results) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 flask
+lxml
+cssselect


### PR DESCRIPTION
Uses a ~~horrifying~~ neat hack I figured out on the /files page. The dropdown list of versions will only contain versions that exist for the project. So it can effectively be used as a complete list with a bit of filtering.

I had to use lxml because regex was just too damn slow on the files page. Too much text I guess? Might be worthwhile to convert the other methods to lxml too, it's a bit cleaner. But not the concern of this PR :smile: 

After/Before:
![](https://cdn.discordapp.com/attachments/254799354248822785/417527816993898516/unknown.png)